### PR TITLE
Stricter Typing

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,10 @@
 import * as React from 'react';
 import './App.css';
 import { MuiThemeProvider } from 'material-ui/styles';
+import { Mode, CellPart, Substance } from './Types';
 
 import OrganelleWrapper from './components/organelle-wrapper';
 import Chart from './components/Chart/chart';
-
-export enum Mode {
-  Normal = 'NORMAL',
-  Assay = 'ASSAY'
-}
-
-export enum CellPart {
-  Nucleus = 'NUCLEUS',
-  Cytoplasm = 'CYTOPLASM',
-  Golgi = 'GOLGI',
-  Gates = 'GATES',
-  Intercell = 'INTERCELL',
-  None = 'NONE'
-}
-
-export enum Substance {
-  Substance1 = 'Substance 1',
-  Substance2 = 'Substance 2',
-  Substance3 = 'Substance 3'
-}
 
 interface AppState {
   addHormone: boolean;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,11 +5,42 @@ import { MuiThemeProvider } from 'material-ui/styles';
 import OrganelleWrapper from './components/organelle-wrapper';
 import Chart from './components/Chart/chart';
 
-interface App {}
+export enum Mode {
+  Normal = 'NORMAL',
+  Assay = 'ASSAY'
+}
 
-class App extends React.Component<any, any> {
+export enum CellPart {
+  Nucleus = 'NUCLEUS',
+  Cytoplasm = 'CYTOPLASM',
+  Golgi = 'GOLGI',
+  Gates = 'GATES',
+  Intercell = 'INTERCELL',
+  None = 'NONE'
+}
 
-  constructor(props: App) {
+interface AppState {
+  addHormone: boolean;
+  addEnzyme: boolean;
+  box1: string;
+  box2: string;
+  modelProperties: ModelProperties;
+  activeAssay: CellPart;
+  mode: Mode;
+  substanceLevels: any;
+}
+
+interface AppProps { }
+
+interface ModelProperties {
+  albino: boolean;
+  working_tyr1: boolean;
+  working_myosin_5a: boolean;
+  open_gates: boolean;
+}
+
+class App extends React.Component<AppProps, AppState> {
+  constructor(props: AppProps) {
     super(props);
     this.state = {
       addHormone: false,
@@ -22,35 +53,35 @@ class App extends React.Component<any, any> {
         open_gates: false
       },
       addEnzyme: false,
-      activeAssay: 'none',
-      mode: 'normal',
+      activeAssay: CellPart.None,
+      mode: Mode.Normal,
       substanceLevels: {
-        cytoplasm: {
+        [CellPart.Cytoplasm]: {
           substance1: 20,
           substance2: 50,
           substance3: 30
         },
-        nucleus: {
+        [CellPart.Nucleus]: {
           substance1: 90,
           substance2: 15,
           substance3: 0
         },
-        golgi: {
+        [CellPart.Golgi]: {
           substance1: 20,
           substance2: 50,
           substance3: 30
         },
-        intercell: {
+        [CellPart.Intercell]: {
           substance1: 0,
           substance2: 0,
           substance3: 70
         },
-        gates: {
+        [CellPart.Gates]: {
           substance1: 30,
           substance2: 50,
           substance3: 70
         },
-        none: {
+        [CellPart.None]: {
           substance1: 0,
           substance2: 0,
           substance3: 0,
@@ -65,7 +96,7 @@ class App extends React.Component<any, any> {
     this.handleAssayClear = this.handleAssayClear.bind(this);
   }
 
-  setActiveAssay(activeAssay: string) {
+  setActiveAssay(activeAssay: CellPart) {
     this.setState({ activeAssay });
   }
 
@@ -108,15 +139,15 @@ class App extends React.Component<any, any> {
   }
 
   handleAssayToggle() {
-    if (this.state.mode === 'assay') {
-      this.setState({mode: 'normal'});
+    if (this.state.mode === Mode.Assay) {
+      this.setState({mode: Mode.Normal});
     } else {
-      this.setState({mode: 'assay'});
+      this.setState({mode: Mode.Assay});
     }
   }
 
   handleAssayClear() {
-    this.setState({ activeAssay: 'none' });
+    this.setState({ activeAssay: CellPart.None });
   }
 
   getBoxView(boxId: any) {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,12 @@ export enum CellPart {
   None = 'NONE'
 }
 
+export enum Substance {
+  Substance1 = 'Substance 1',
+  Substance2 = 'Substance 2',
+  Substance3 = 'Substance 3'
+}
+
 interface AppState {
   addHormone: boolean;
   addEnzyme: boolean;
@@ -27,7 +33,7 @@ interface AppState {
   modelProperties: ModelProperties;
   activeAssay: CellPart;
   mode: Mode;
-  substanceLevels: any;
+  substanceLevels: { [cellPart in CellPart]: { [substance in Substance]: number} };
 }
 
 interface AppProps { }
@@ -57,34 +63,34 @@ class App extends React.Component<AppProps, AppState> {
       mode: Mode.Normal,
       substanceLevels: {
         [CellPart.Cytoplasm]: {
-          substance1: 20,
-          substance2: 50,
-          substance3: 30
+          [Substance.Substance1]: 20,
+          [Substance.Substance2]: 50,
+          [Substance.Substance3]: 30
         },
         [CellPart.Nucleus]: {
-          substance1: 90,
-          substance2: 15,
-          substance3: 0
+          [Substance.Substance1]: 90,
+          [Substance.Substance2]: 15,
+          [Substance.Substance3]: 0
         },
         [CellPart.Golgi]: {
-          substance1: 20,
-          substance2: 50,
-          substance3: 30
+          [Substance.Substance1]: 20,
+          [Substance.Substance2]: 50,
+          [Substance.Substance3]: 30
         },
         [CellPart.Intercell]: {
-          substance1: 0,
-          substance2: 0,
-          substance3: 70
+          [Substance.Substance1]: 0,
+          [Substance.Substance2]: 0,
+          [Substance.Substance3]: 70
         },
         [CellPart.Gates]: {
-          substance1: 30,
-          substance2: 50,
-          substance3: 70
+          [Substance.Substance1]: 30,
+          [Substance.Substance2]: 50,
+          [Substance.Substance3]: 70
         },
         [CellPart.None]: {
-          substance1: 0,
-          substance2: 0,
-          substance3: 0,
+          [Substance.Substance1]: 0,
+          [Substance.Substance2]: 0,
+          [Substance.Substance3]: 0,
         }
       }
     };
@@ -111,7 +117,7 @@ class App extends React.Component<AppProps, AppState> {
 
   handleEnzymeClick() {
     let newSubstances = Object.assign({}, this.state.substanceLevels);
-    newSubstances.cytoplasm.substance3 = 60;
+    newSubstances[CellPart.Cytoplasm][Substance.Substance3] = 60;
     this.setState({
       addEnzyme: true,
       modelProperties: {
@@ -124,7 +130,7 @@ class App extends React.Component<AppProps, AppState> {
     });
     setTimeout(() => {
       newSubstances = Object.assign({}, this.state.substanceLevels);
-      newSubstances.cytoplasm.substance3 = 30;
+      newSubstances[CellPart.Cytoplasm][Substance.Substance3] = 30;
       this.setState({
         addEnzyme: false,
         modelProperties: {
@@ -212,7 +218,7 @@ class App extends React.Component<AppProps, AppState> {
               </div>
             </div>
             <Chart 
-              substances={this.state.substanceLevels} 
+              substanceLevels={this.state.substanceLevels} 
               activeAssay={this.state.activeAssay} 
               mode={this.state.mode} 
               onAssayToggle={this.handleAssayToggle}

--- a/src/Types.tsx
+++ b/src/Types.tsx
@@ -1,0 +1,19 @@
+export enum Mode {
+  Normal = 'NORMAL',
+  Assay = 'ASSAY'
+}
+
+export enum CellPart {
+  Nucleus = 'NUCLEUS',
+  Cytoplasm = 'CYTOPLASM',
+  Golgi = 'GOLGI',
+  Gates = 'GATES',
+  Intercell = 'INTERCELL',
+  None = 'NONE'
+}
+
+export enum Substance {
+  Substance1 = 'Substance 1',
+  Substance2 = 'Substance 2',
+  Substance3 = 'Substance 3'
+}

--- a/src/components/Chart/chart.tsx
+++ b/src/components/Chart/chart.tsx
@@ -17,7 +17,7 @@ interface ChartState {
 }
 
 class Chart extends React.Component<ChartProps, ChartState> {
-  baseData: any = {
+  baseData: Chart.ChartData = {
     datasets: [ {} ]
   };
   constructor(props: any) {
@@ -45,14 +45,14 @@ class Chart extends React.Component<ChartProps, ChartState> {
     let values = activeSubstances.map(function(substance: Substance) {
       return substanceLevels[activeAssay][substance];
     });
-    let data: any = Object.assign({}, this.baseData);
+    let data: Chart.ChartData = Object.assign({}, this.baseData);
     data.labels = activeSubstances;
     data.datasets[0].data = values;
     data.datasets[0].label = activeAssay;
 
     let color = activeAssay === CellPart.None ? 'rgba(0, 0, 0, 0)' : 'rgba(255, 99, 132, 0.6)';
     data.datasets[0].backgroundColor = color;
-    let options: any = {
+    let options: Chart.ChartOptions = {
       title: {
         display: true,
         text: 'Substance Breakdown',
@@ -65,7 +65,7 @@ class Chart extends React.Component<ChartProps, ChartState> {
       scales: {
         xAxes: [{
           ticks: {
-            beginAtZero: true,
+            min: 0,
             max: 100
           }
         }]

--- a/src/components/Chart/chart.tsx
+++ b/src/components/Chart/chart.tsx
@@ -1,9 +1,22 @@
 import * as React from 'react';
 import { HorizontalBar } from 'react-chartjs-2';
 import { RaisedButton, Checkbox } from 'material-ui';
+import { CellPart, Mode } from '../../App';
 import './chart.css';
 
-class Chart extends React.Component<any, any> {
+interface ChartProps {
+  substances: any;
+  activeAssay: CellPart;
+  mode: Mode;
+  onAssayToggle(): void;
+  onAssayClear(): void;
+}
+
+interface ChartState {
+  displaySubstances: any;
+}
+
+class Chart extends React.Component<ChartProps, ChartState> {
   baseData: any = {
     datasets: [ {} ]
   };
@@ -37,7 +50,7 @@ class Chart extends React.Component<any, any> {
     data.datasets[0].data = values;
     data.datasets[0].label = activeAssay;
 
-    let color = activeAssay === 'none' ? 'rgba(0, 0, 0, 0)' : 'rgba(255, 99, 132, 0.6)';
+    let color = activeAssay === CellPart.None ? 'rgba(0, 0, 0, 0)' : 'rgba(255, 99, 132, 0.6)';
     data.datasets[0].backgroundColor = color;
     let options: any = {
       title: {
@@ -46,7 +59,7 @@ class Chart extends React.Component<any, any> {
         fontSize: 25
       },
       legend: {
-        display: activeAssay !== 'none',
+        display: activeAssay !== CellPart.None,
         position: 'bottom'
       },
       scales: {
@@ -69,15 +82,15 @@ class Chart extends React.Component<any, any> {
         />
         <div className="chart-buttons">
           <RaisedButton 
-            label={(this.props.mode === 'assay' ? 'Confirm' : 'Begin') + ' assay'}
+            label={(this.props.mode === Mode.Assay ? 'Confirm' : 'Begin') + ' assay'}
             onClick={this.props.onAssayToggle}
             style={{width: '150px', margin: '5px'}}
-            primary={this.props.mode !== 'assay'}
-            secondary={this.props.mode === 'assay'}
+            primary={this.props.mode !== Mode.Assay}
+            secondary={this.props.mode === Mode.Assay}
           />
           <RaisedButton 
             label={'Clear assays'}
-            disabled={this.props.mode === 'assay'}
+            disabled={this.props.mode === Mode.Assay}
             onClick={this.props.onAssayClear}
             style={{width: '150px', margin: '5px'}}
             primary={true}

--- a/src/components/Chart/chart.tsx
+++ b/src/components/Chart/chart.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { HorizontalBar } from 'react-chartjs-2';
 import { RaisedButton, Checkbox } from 'material-ui';
-import { CellPart, Mode, Substance } from '../../App';
+import { CellPart, Mode, Substance } from '../../Types';
 import './chart.css';
 
 interface ChartProps {

--- a/src/components/Chart/chart.tsx
+++ b/src/components/Chart/chart.tsx
@@ -1,11 +1,11 @@
 import * as React from 'react';
 import { HorizontalBar } from 'react-chartjs-2';
 import { RaisedButton, Checkbox } from 'material-ui';
-import { CellPart, Mode } from '../../App';
+import { CellPart, Mode, Substance } from '../../App';
 import './chart.css';
 
 interface ChartProps {
-  substances: any;
+  substanceLevels: { [cellPart in CellPart]: { [substance in Substance]: number} };
   activeAssay: CellPart;
   mode: Mode;
   onAssayToggle(): void;
@@ -13,7 +13,7 @@ interface ChartProps {
 }
 
 interface ChartState {
-  displaySubstances: any;
+  displaySubstances: { [substance in Substance]: boolean};
 }
 
 class Chart extends React.Component<ChartProps, ChartState> {
@@ -24,9 +24,9 @@ class Chart extends React.Component<ChartProps, ChartState> {
     super(props);
     this.state = {
       displaySubstances: {
-        substance1: false,
-        substance2: true,
-        substance3: true
+        [Substance.Substance1]: false,
+        [Substance.Substance2]: true,
+        [Substance.Substance3]: true
       }
     };
     this.updateCheck = this.updateCheck.bind(this);
@@ -39,11 +39,11 @@ class Chart extends React.Component<ChartProps, ChartState> {
   }
 
   render() {
-    let {substances, activeAssay} = this.props;
+    let {substanceLevels, activeAssay} = this.props;
     let {displaySubstances} = this.state;
     let activeSubstances = Object.keys(displaySubstances).filter((substanceKey) => displaySubstances[substanceKey]);
-    let values = activeSubstances.map(function(e: any) {
-      return substances[activeAssay][e];
+    let values = activeSubstances.map(function(substance: Substance) {
+      return substanceLevels[activeAssay][substance];
     });
     let data: any = Object.assign({}, this.baseData);
     data.labels = activeSubstances;
@@ -99,22 +99,22 @@ class Chart extends React.Component<ChartProps, ChartState> {
         <div className="chart-boxes">
           <Checkbox 
             style={{width: '150px'}} 
-            checked={this.state.displaySubstances.substance1} 
-            id={'substance1'} 
+            checked={this.state.displaySubstances[Substance.Substance1]} 
+            id={Substance.Substance1} 
             label={'Substance 1'} 
             onCheck={this.updateCheck} 
           />
           <Checkbox 
             style={{width: '150px'}} 
-            checked={this.state.displaySubstances.substance2} 
-            id={'substance2'} 
+            checked={this.state.displaySubstances[Substance.Substance2]} 
+            id={Substance.Substance2} 
             label={'Substance 2'} 
             onCheck={this.updateCheck} 
           />
           <Checkbox 
             style={{width: '150px'}} 
-            checked={this.state.displaySubstances.substance3} 
-            id={'substance3'} 
+            checked={this.state.displaySubstances[Substance.Substance3]} 
+            id={Substance.Substance3} 
             label={'Substance 3'} 
             onCheck={this.updateCheck} 
           />

--- a/src/components/organelle-wrapper.tsx
+++ b/src/components/organelle-wrapper.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { CellPart, Mode } from '../App';
+import { CellPart, Mode } from '../Types';
 
 declare var Organelle: any;
 

--- a/src/components/organelle-wrapper.tsx
+++ b/src/components/organelle-wrapper.tsx
@@ -1,4 +1,6 @@
 import * as React from 'react';
+import { CellPart, Mode } from '../App';
+
 declare var Organelle: any;
 
 interface OrganelleWrapperProps {
@@ -6,10 +8,10 @@ interface OrganelleWrapperProps {
   modelProperties: any;
   doAddHormone: boolean;
   addEnzyme: boolean;
-  setActiveAssay: Function;
   currentView: any;
-  mode: string;
-  activeAssay: string;
+  mode: Mode;
+  activeAssay: CellPart;
+  setActiveAssay(cellPart: CellPart): void;
 }
 
 interface OrganelleWrapperState {
@@ -19,24 +21,24 @@ interface OrganelleWrapperState {
 class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleWrapperState> {
     model: any;
     organelleInfo: any = {
-      'nucleus': {
+      [CellPart.Nucleus]: {
         selector: '#nucleus'
       },
-      'cytoplasm': {
+      [CellPart.Cytoplasm]: {
         selector: '#cytoplasm',
         opaqueSelector: '#cellshape_0_Layer0_0_FILL'
       },
-      'golgi': {
+      [CellPart.Golgi]: {
         selector: '#golgi_x5F_apparatus'
       },
-      'gates': {
+      [CellPart.Gates]: {
         selector: '.gate-a, .gate-b, .gate-c, .gate-d'
       },
-      'intercell': {
+      [CellPart.Intercell]: {
         selector: `#intercell`,
         opaqueSelector: '#Layer6_0_FILL'
       },
-      'none': {
+      [CellPart.None]: {
         selector: ''
       }
     };
@@ -117,24 +119,24 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
       },
       clickHandlers: [
         {
-          selector: this.organelleInfo.cytoplasm.selector,
-          action: this.organelleClick.bind(this, 'cytoplasm')
+          selector: this.organelleInfo[CellPart.Cytoplasm].selector,
+          action: this.organelleClick.bind(this, CellPart.Cytoplasm)
         },
         {
-          selector: this.organelleInfo.nucleus.selector,
-          action: this.organelleClick.bind(this, 'nucleus')
+          selector: this.organelleInfo[CellPart.Nucleus].selector,
+          action: this.organelleClick.bind(this, CellPart.Nucleus)
         },
         {
-          selector: this.organelleInfo.golgi.selector,
-          action: this.organelleClick.bind(this, 'golgi')
+          selector: this.organelleInfo[CellPart.Golgi].selector,
+          action: this.organelleClick.bind(this, CellPart.Golgi)
         },
         {
-          selector: this.organelleInfo.intercell.selector,
-          action: this.organelleClick.bind(this, 'intercell')
+          selector: this.organelleInfo[CellPart.Intercell].selector,
+          action: this.organelleClick.bind(this, CellPart.Intercell)
         },
         {
-          selector: this.organelleInfo.gates.selector,
-          action: this.organelleClick.bind(this, 'gates')
+          selector: this.organelleInfo[CellPart.Gates].selector,
+          action: this.organelleClick.bind(this, CellPart.Gates)
         }
       ],
       species: [
@@ -179,7 +181,7 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
     });
 
     this.model.on('view.hover.enter', (evt: any) => {
-      if (this.props.mode !== 'assay') {
+      if (this.props.mode !== Mode.Assay) {
         return;
       }
       const hoveredOrganelle = Object.keys(this.organelleInfo)
@@ -197,7 +199,7 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
     });
 
     this.model.on('view.hover.exit', (evt: any) => {
-      if (this.props.mode !== 'assay') {
+      if (this.props.mode !== Mode.Assay) {
         return;
       }
 
@@ -206,7 +208,7 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
   }
 
   updateCellOpacity() {
-    if (this.props.mode === 'assay') {
+    if (this.props.mode === Mode.Assay) {
       let opaqueSelectors = [];
       let activeAssaySelector = this.organelleInfo[this.props.activeAssay].opaqueSelector ?
         this.organelleInfo[this.props.activeAssay].opaqueSelector :
@@ -236,8 +238,8 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
     this.model.view.resetPropertiesOnAllObjects();
   }
 
-  organelleClick(organelle: string) {
-    if (this.props.mode === 'assay') {
+  organelleClick(organelle: CellPart) {
+    if (this.props.mode === Mode.Assay) {
       this.props.setActiveAssay(organelle);
     }
   }


### PR DESCRIPTION
Hi @sfentress - I spent the rest of today trying to improve type-checking throughout the project. This mostly consisted of two things: adding `interfaces` to check `state` and `prop` types on all components, and replacing `string` values with `enums` where possible. I think this will set better standards moving forward.

The main thing I'm not sure about is where to put the new `enums` and some of the new `interfaces`. Right now, they're all in the top-level app, and imported by children, but that feels kind of clunky. Let me know if you have any better ideas!