### PR TITLE
Sustained substances after addition; add pheomelanin

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,11 +17,8 @@ const STEP_MS = 100;
 
 @observer
 class App extends React.Component<AppProps> {
-  currentTime: number;
-
   constructor(props: AppProps) {
     super(props);
-    this.currentTime = 0;
     this.handleAssayToggle = this.handleAssayToggle.bind(this);
     this.handleAssayClear = this.handleAssayClear.bind(this);
     this.simulationTick = this.simulationTick.bind(this);
@@ -33,8 +30,7 @@ class App extends React.Component<AppProps> {
   }
 
   simulationTick(msPassed: number) {
-    this.currentTime += msPassed;
-    rootStore.step(this.currentTime);
+    rootStore.step(msPassed);
     setTimeout(this.simulationTick.bind(this, STEP_MS), STEP_MS);
   }
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,8 +17,11 @@ const STEP_MS = 100;
 
 @observer
 class App extends React.Component<AppProps> {
+  currentTime: number;
+
   constructor(props: AppProps) {
     super(props);
+    this.currentTime = 0;
     this.handleAssayToggle = this.handleAssayToggle.bind(this);
     this.handleAssayClear = this.handleAssayClear.bind(this);
     this.simulationTick = this.simulationTick.bind(this);
@@ -30,7 +33,8 @@ class App extends React.Component<AppProps> {
   }
 
   simulationTick(msPassed: number) {
-    rootStore.step(msPassed);
+    this.currentTime += msPassed;
+    rootStore.step(this.currentTime);
     setTimeout(this.simulationTick.bind(this, STEP_MS), STEP_MS);
   }
 

--- a/src/components/Assay/AssayBarChart.tsx
+++ b/src/components/Assay/AssayBarChart.tsx
@@ -70,6 +70,8 @@ class AssayBarChart extends React.Component<AssayBarProps, AssayBarState> {
         return allColors[1];
       case SubstanceType.Eumelanin:
         return allColors[2];
+        case SubstanceType.Pheomelanin:
+          return allColors[3];
     }
   }
 

--- a/src/components/Assay/AssayBarChart.tsx
+++ b/src/components/Assay/AssayBarChart.tsx
@@ -138,7 +138,7 @@ class AssayBarChart extends React.Component<AssayBarProps, AssayBarState> {
         <HorizontalBar
           data={data}
           options={options}
-          height={300}
+          height={346}
         />
     );
   }

--- a/src/components/Assay/AssayLineGraph.tsx
+++ b/src/components/Assay/AssayLineGraph.tsx
@@ -54,7 +54,7 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
     });
     return {
       data,
-      label: assayInfo.organism.id + ' ' + assayInfo.organelleType.toLowerCase() + ' ' 
+      label: assayInfo.organism.id + ' ' + assayInfo.organelleType.toLowerCase() + ' '
         + activeSubstance.toLowerCase(),
       borderWidth: 3,
       backgroundColor: this.props.colors[lineNum],
@@ -69,7 +69,7 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
     let {activeAssay, lockedAssays} = rootStore;
     let activeSubstances = visibleSubstances.keys()
       .filter((substanceKey) => visibleSubstances.get(substanceKey))
-      .map((activeSubstance) => 
+      .map((activeSubstance) =>
         stringToEnum(activeSubstance, SubstanceType));
 
     let data: any = {
@@ -129,7 +129,7 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
         <Scatter
           data={data}
           options={options}
-          height={300}
+          height={346}
         />
     );
   }

--- a/src/components/Assay/AssayTool.tsx
+++ b/src/components/Assay/AssayTool.tsx
@@ -85,31 +85,6 @@ class AssayTool extends React.Component<AssayToolProps, AssayToolState> {
             icon={assayStore.graphType === GraphType.Line ? <NoClockIcon /> : <ClockIcon />}
           />
         </div>
-        {/*
-        <div className="chart-boxes">
-          <Checkbox
-            style={{width: '200px'}}
-            checked={assayStore.visibleSubstances.get(SubstanceType.Hormone)}
-            id={SubstanceType.Hormone}
-            label={'Hormone'}
-            onCheck={this.updateCheck}
-          />
-          <Checkbox
-            style={{width: '200px'}}
-            checked={assayStore.visibleSubstances.get(SubstanceType.GProtein)}
-            id={SubstanceType.GProtein}
-            label={'Activated G-Protein'}
-            onCheck={this.updateCheck}
-          />
-          <Checkbox
-            style={{width: '200px'}}
-            checked={assayStore.visibleSubstances.get(SubstanceType.Eumelanin)}
-            id={SubstanceType.Eumelanin}
-            label={'Eumelanin'}
-            onCheck={this.updateCheck}
-          />
-        </div>
-        */}
       </div>
     );
   }

--- a/src/components/SubstanceManipulator/SubstanceManipulator.tsx
+++ b/src/components/SubstanceManipulator/SubstanceManipulator.tsx
@@ -30,14 +30,15 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
     this.setState({
       selectedSubstance: value
     });
+    rootStore.setActiveSubstance(value);
   }
 
   handleAddModeToggle() {
-    rootStore.toggleSubstanceManipulator(Mode.Add, this.state.selectedSubstance, SUBSTANCE_DELTA);
+    rootStore.toggleSubstanceManipulator(Mode.Add, SUBSTANCE_DELTA);
   }
 
   handleSubtractModeToggle() {
-    rootStore.toggleSubstanceManipulator(Mode.Subtract, this.state.selectedSubstance, SUBSTANCE_DELTA * -1);
+    rootStore.toggleSubstanceManipulator(Mode.Subtract, SUBSTANCE_DELTA * -1);
   }
 
   render() {
@@ -74,21 +75,18 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.Hormone}
             label="Hormone"
-            disabled={mode !== Mode.Normal}
           />
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.GProtein}
             label="Activated G-Protein"
-            disabled={mode !== Mode.Normal}
           />
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.Eumelanin}
             label="Eumelanin"
-            disabled={mode !== Mode.Normal}
           />
         </RadioButtonGroup>
       </div>

--- a/src/components/SubstanceManipulator/SubstanceManipulator.tsx
+++ b/src/components/SubstanceManipulator/SubstanceManipulator.tsx
@@ -88,6 +88,12 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
             value={SubstanceType.Eumelanin}
             label="Eumelanin"
           />
+          <RadioButton
+            style={{width: '200px'}}
+            labelStyle={{ fontSize: '12px'}}
+            value={SubstanceType.Pheomelanin}
+            label="Pheomelanin"
+          />
         </RadioButtonGroup>
       </div>
     );

--- a/src/components/organelle-wrapper.tsx
+++ b/src/components/organelle-wrapper.tsx
@@ -7,7 +7,7 @@ import { OrganelleType } from '../models/Organelle';
 import { rootStore, Mode } from '../stores/RootStore';
 import { createModel } from 'organelle';
 import * as CellModels from '../cell-models/index';
-import { SubstanceType, ISubstance } from '../models/Substance';
+import { SubstanceType } from '../models/Substance';
 
 interface OrganelleWrapperProps {
   name: string;
@@ -269,7 +269,7 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
       // update substance levels
       rootStore.changeSubstanceLevel(OrganelleRef.create({ organism: this.props.organism, organelleType }));
       // show animation in model
-      let {substanceType} = rootStore.activeSubstanceManipulation as ISubstance;
+      let substanceType = rootStore.activeSubstance;
       if (substanceType === SubstanceType.Hormone) {
         this.addHormone(organelleType, location);
       } else if (substanceType === SubstanceType.GProtein && this.props.currentView === View.Receptor) {

--- a/src/models/Organelle.tsx
+++ b/src/models/Organelle.tsx
@@ -33,25 +33,18 @@ export const Organelle: any = types
     }
   }))
   .actions(self => ({
-    incrementSubstance(substanceType: SubstanceType, amount: number) {
+    incrementSubstance(substanceType: SubstanceType, amount: number, currentTime: number) {
       let substanceLevel: ISubstance = self.substanceDeltas.get(substanceType);
-      if (substanceLevel) {
-        substanceLevel.manuallyIncrement(amount, self);
-      } else {
-        self.substanceDeltas.set(substanceType, Substance.create({
-          type: substanceType,
-          amount: amount
-        }));
-      }
+      substanceLevel.manuallyIncrement(amount, self, currentTime);
     },
-    step(msPassed: number, parentOrganism: IOrganism) {
+    step(currentTime: number, parentOrganism: IOrganism) {
       Object.keys(SubstanceType).map(key => SubstanceType[key]).forEach(substanceType => {
         let substance = self.substanceDeltas.get(substanceType) as ISubstance;
         if (!substance) {
           substance = Substance.create({type: substanceType});
           self.substanceDeltas.set(substanceType, substance);
         }
-        substance.step(msPassed, parentOrganism, self);
+        substance.step(currentTime, parentOrganism, self);
       });
     }
   }));

--- a/src/models/Organelle.tsx
+++ b/src/models/Organelle.tsx
@@ -36,7 +36,7 @@ export const Organelle: any = types
     incrementSubstance(substanceType: SubstanceType, amount: number) {
       let substanceLevel: ISubstance = self.substanceDeltas.get(substanceType);
       if (substanceLevel) {
-        substanceLevel.increment(amount, self);
+        substanceLevel.manuallyIncrement(amount, self);
       } else {
         self.substanceDeltas.set(substanceType, Substance.create({
           type: substanceType,

--- a/src/models/Organism.tsx
+++ b/src/models/Organism.tsx
@@ -107,24 +107,24 @@ export const Organism = types
     },
   }))
   .actions(self => ({
-    incrementOrganelleSubstance(organelleType: string, substanceType: SubstanceType, amount: number) {
+    incrementOrganelleSubstance(organelleType: string, substanceType: SubstanceType, amount: number, currentTime: number) {
       let organelle = self.organelles.get(organelleType) as IOrganelle;
       if (organelle) {
-        organelle.incrementSubstance(substanceType, amount);
+        organelle.incrementSubstance(substanceType, amount, currentTime);
       } else {
         let newOrganelle = Organelle.create({ type: organelleType });
-        newOrganelle.incrementSubstance(substanceType, amount);
+        newOrganelle.incrementSubstance(substanceType, amount, currentTime);
         self.organelles.set(organelleType, newOrganelle);
       }
     },
-    step(msPassed: number) {
+    step(currentTime: number) {
       Object.keys(OrganelleType).map(key => OrganelleType[key]).forEach(organelleType => {
         let organelle = self.organelles.get(organelleType) as IOrganelle;
         if (!organelle) {
           organelle = Organelle.create({type: organelleType});
           self.organelles.set(organelleType, organelle);
         }
-        organelle.step(msPassed, self);
+        organelle.step(currentTime, self);
       });
     }
   }));

--- a/src/models/Organism.tsx
+++ b/src/models/Organism.tsx
@@ -48,9 +48,9 @@ export const Organism = types
       let eumelaninLevel = self.getTotalForOrganelleSubstance(
         OrganelleType.Melanosome, SubstanceType.Eumelanin
       );
-      return eumelaninLevel < 10
+      return eumelaninLevel < 200
         ? Darkness.LIGHT
-        : eumelaninLevel > 575
+        : eumelaninLevel > 400
           ? Darkness.DARKEST
           : Darkness.DARK;
     },
@@ -145,7 +145,7 @@ export const BeachMouse = Organism.create({
       substanceLevels: {
         [SubstanceType.Hormone] : {
           type: SubstanceType.Hormone,
-          amount: 286
+          amount: 125
         }
       }
     },
@@ -178,7 +178,7 @@ export const FieldMouse = Organism.create({
       substanceLevels: {
         [SubstanceType.Hormone] : {
           type: SubstanceType.Hormone,
-          amount: 286
+          amount: 125
         }
       }
     },
@@ -187,7 +187,7 @@ export const FieldMouse = Organism.create({
       substanceLevels: {
         [SubstanceType.GProtein] : {
           type: SubstanceType.GProtein,
-          amount: 589
+          amount: 170
         }
       }
     },
@@ -196,7 +196,7 @@ export const FieldMouse = Organism.create({
       substanceLevels: {
         [SubstanceType.Eumelanin] : {
           type: SubstanceType.Eumelanin,
-          amount: 533
+          amount: 340
         }
       }
     }

--- a/src/models/Organism.tsx
+++ b/src/models/Organism.tsx
@@ -164,6 +164,10 @@ export const BeachMouse = Organism.create({
         [SubstanceType.Eumelanin] : {
           type: SubstanceType.Eumelanin,
           amount: 0
+        },
+        [SubstanceType.Pheomelanin] : {
+          type: SubstanceType.Pheomelanin,
+          amount: 316
         }
       }
     }
@@ -197,6 +201,10 @@ export const FieldMouse = Organism.create({
         [SubstanceType.Eumelanin] : {
           type: SubstanceType.Eumelanin,
           amount: 340
+        },
+        [SubstanceType.Pheomelanin] : {
+          type: SubstanceType.Pheomelanin,
+          amount: 147
         }
       }
     }

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -59,25 +59,25 @@ export const Substance: any = types
       switch (self.type) {
         case SubstanceType.Hormone:
           birthRate = parentOrganelle.type === OrganelleType.Intercell
-            ? (300 - .5 * hormoneAmount) / 20
+            ? 300 / 20
             : 0;
-          deathRate = (100 + .2 * hormoneAmount) / 20;
+          deathRate = (100 + 1.6 * hormoneAmount) / 20;
           break;
         case SubstanceType.GProtein:
           birthRate = parentOrganelle.type === OrganelleType.Cytoplasm
             ? parentOrganism.id === 'Field Mouse'
-              ? (150 - .1 * gProteinAmount + .8 * hormoneAmount) / 10
-              : (25 - .1 * gProteinAmount) / 10
+              ? (180 + .8 * hormoneAmount) / 10
+              : 25 / 10
             : 0;
-          deathRate = (25 + .5 * gProteinAmount) / 10;
+          deathRate = (25 + 1.5 * gProteinAmount) / 10;
           break;
         case SubstanceType.Eumelanin:
           birthRate = parentOrganelle.type === OrganelleType.Melanosome
             ? parentOrganism.id === 'Field Mouse'
-              ? (50 - .1 * eumelaninAmount + .5 * gProteinAmount) / 10
-              : (25 - .1 * eumelaninAmount + .5 * gProteinAmount) / 10
+              ? (280 + 1.5 * gProteinAmount) / 10
+              : (25 + 1.8 * gProteinAmount) / 10
             : 0;
-          deathRate = (25 + .5 * eumelaninAmount) / 10;
+          deathRate = (25 + 1.5 * eumelaninAmount) / 10;
           break;
         default:
           birthRate = 0;

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -16,7 +16,6 @@ export const Substance: any = types
   .model('Substance', {
     type: types.enumeration('SubstanceType', Object.keys(SubstanceType).map(key => SubstanceType[key])),
     amount: types.optional(types.number, 0),
-    currentTime: types.optional(types.number, 0),
     fixedValueEndTime: types.optional(types.number, 0)
   })
   .views(self => ({
@@ -35,15 +34,14 @@ export const Substance: any = types
     }
   }))
   .actions(self => ({
-    manuallyIncrement(amount: number, parentOrganelle: IOrganelle) {
+    manuallyIncrement(amount: number, parentOrganelle: IOrganelle, currentTime: number) {
       self.increment(amount, parentOrganelle);
-      self.fixedValueEndTime = self.currentTime + substanceManipulationTime;
+      self.fixedValueEndTime = currentTime + substanceManipulationTime;
     },
 
     // Cell models can be viewed here:
     // https://docs.google.com/spreadsheets/d/19f0nk-F3UQ_-A-agq5JnuhJXGCtFYMT_JcYCQkyqnQI/edit
-    step(milliseconds: number, parentOrganism: IOrganism, parentOrganelle: IOrganelle) {
-      self.currentTime = milliseconds;
+    step(currentTime: number, parentOrganism: IOrganism, parentOrganelle: IOrganelle) {
       let birthRate, deathRate;
       let hormoneAmount = parentOrganism.getTotalForOrganelleSubstance(
         OrganelleType.Intercell, SubstanceType.Hormone);
@@ -54,7 +52,7 @@ export const Substance: any = types
       let pheomelaninAmount = parentOrganism.getTotalForOrganelleSubstance(
         OrganelleType.Melanosome, SubstanceType.Pheomelanin);
 
-      if (self.fixedValueEndTime > milliseconds) {
+      if (self.fixedValueEndTime > currentTime) {
         // User has recently set value, and we want to stay at this value
         return;
       }

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -6,7 +6,8 @@ import { OrganelleType, IOrganelle } from './Organelle';
 export enum SubstanceType {
   Hormone = 'Hormone',
   GProtein = 'G-Protein',
-  Eumelanin = 'Eumelanin'
+  Eumelanin = 'Eumelanin',
+  Pheomelanin = 'Pheomelanin'
 }
 
 const substanceManipulationTime = 2500;
@@ -50,6 +51,8 @@ export const Substance: any = types
         OrganelleType.Cytoplasm, SubstanceType.GProtein);
       let eumelaninAmount = parentOrganism.getTotalForOrganelleSubstance(
         OrganelleType.Melanosome, SubstanceType.Eumelanin);
+      let pheomelaninAmount = parentOrganism.getTotalForOrganelleSubstance(
+        OrganelleType.Melanosome, SubstanceType.Pheomelanin);
 
       if (self.fixedValueEndTime > milliseconds) {
         // User has recently set value, and we want to stay at this value
@@ -78,6 +81,12 @@ export const Substance: any = types
               : (25 + 1.8 * gProteinAmount) / 10
             : 0;
           deathRate = (25 + 1.5 * eumelaninAmount) / 10;
+          break;
+        case SubstanceType.Pheomelanin:
+          birthRate = parentOrganelle.type === OrganelleType.Melanosome
+            ? (500 - 1.5 * gProteinAmount) / 10
+            : 0;
+          deathRate = (25 + 1.5 * pheomelaninAmount) / 10;
           break;
         default:
           birthRate = 0;

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -23,10 +23,14 @@ export const Substance: any = types
     increment(amount: number, parentOrganelle: IOrganelle) {
       let base = parentOrganelle.getLevelForSubstance(self.type);
       self.amount = Math.max(self.amount + amount, -1 * base);
+    },
+
+    setType(substanceType: SubstanceType) {
+      self.type = substanceType;
     }
   }))
   .actions(self => ({
-    // Cell models can be viewed here: 
+    // Cell models can be viewed here:
     // https://docs.google.com/spreadsheets/d/19f0nk-F3UQ_-A-agq5JnuhJXGCtFYMT_JcYCQkyqnQI/edit
     step(milliseconds: number, parentOrganism: IOrganism, parentOrganelle: IOrganelle) {
       let birthRate, deathRate;
@@ -39,7 +43,7 @@ export const Substance: any = types
 
       switch (self.type) {
         case SubstanceType.Hormone:
-          birthRate = parentOrganelle.type === OrganelleType.Intercell 
+          birthRate = parentOrganelle.type === OrganelleType.Intercell
             ? (300 - .5 * hormoneAmount) / 20
             : 0;
           deathRate = (100 + .2 * hormoneAmount) / 20;

--- a/src/stores/AssayStore.tsx
+++ b/src/stores/AssayStore.tsx
@@ -31,7 +31,8 @@ export const assayStore = AssayStore.create({
   visibleSubstances: {
     [SubstanceType.Hormone]: true,
     [SubstanceType.GProtein]: true,
-    [SubstanceType.Eumelanin]: true
+    [SubstanceType.Eumelanin]: true,
+    [SubstanceType.Pheomelanin]: true
   },
   graph: GraphType.Bar
 });

--- a/src/stores/RootStore.tsx
+++ b/src/stores/RootStore.tsx
@@ -44,7 +44,7 @@ const RootStore = types
 
     step(msPassed: number) {
       self.organisms.keys().forEach(orgKey => {
-        self.organisms.get(orgKey).step(msPassed);
+        self.organisms.get(orgKey).step(self.time);
       });
 
       self.time += msPassed;
@@ -82,7 +82,10 @@ const RootStore = types
 
     changeSubstanceLevel(organelleRef: IOrganelleRef) {
       self.organisms.get(organelleRef.organism.id).incrementOrganelleSubstance(
-        organelleRef.organelleType, stringToEnum(self.activeSubstance, SubstanceType), self.activeSubstanceAmount);
+        organelleRef.organelleType, 
+        stringToEnum(self.activeSubstance, SubstanceType), 
+        self.activeSubstanceAmount, 
+        self.time);
       self.setMode(Mode.Normal);
     }
   }));

--- a/src/stores/RootStore.tsx
+++ b/src/stores/RootStore.tsx
@@ -18,6 +18,8 @@ const RootStore = types
     organisms: types.map(Organism),
     activeAssay: types.maybe(OrganelleRef),
     lockedAssays: types.optional(types.array(OrganelleRef), []),
+    activeSubstance: types.enumeration('SubstanceType', Object.keys(SubstanceType).map(key => SubstanceType[key])),
+    activeSubstanceAmount: types.optional(types.number, 0),
     activeSubstanceManipulation: types.maybe(Substance),
     time: types.optional(types.number, 0),
     appStore: AppStore,
@@ -32,11 +34,24 @@ const RootStore = types
       self.lockedAssays = assayOrganelles;
     },
 
-    setActiveSubstanceManipulation(substanceType: SubstanceType, amount: number) {
-      self.activeSubstanceManipulation = Substance.create({
-        type: substanceType,
-        amount
-      });
+    setActiveSubstance(substance: SubstanceType) {
+      self.activeSubstance = substance;
+      if (self.activeSubstanceAmount) {
+        self.activeSubstanceManipulation = Substance.create({
+          type: substance,
+          amount: self.activeSubstanceAmount
+        });
+      }
+    },
+
+    setActiveSubstanceAmount(amount: number) {
+      self.activeSubstanceAmount = amount;
+      if (self.activeSubstance) {
+        self.activeSubstanceManipulation = Substance.create({
+          type: self.activeSubstance,
+          amount: amount
+        });
+      }
     },
 
     step(msPassed: number) {
@@ -68,10 +83,10 @@ const RootStore = types
       self.setLockedAssays([]);
     },
 
-    toggleSubstanceManipulator(manipulationMode: Mode, substance: SubstanceType, amount: number) {
+    toggleSubstanceManipulator(manipulationMode: Mode, amount: number) {
       if (self.mode === Mode.Normal) {
         self.setMode(manipulationMode);
-        self.setActiveSubstanceManipulation(substance, amount);
+        self.setActiveSubstanceAmount(amount);
       } else {
         self.setMode(Mode.Normal);
       }
@@ -91,6 +106,7 @@ export const rootStore = RootStore.create({
     'Beach Mouse': BeachMouse,
     'Field Mouse': FieldMouse
   },
+  activeSubstance: SubstanceType.Hormone,
   appStore,
   assayStore
 });


### PR DESCRIPTION
Hi @ekosmin, just a couple more for you to check, I'll bring in the simple ones.

This makes it so that when a user adds a substance, it remains at the raised level for several seconds.

I did this by making it such that `rootStore.currentTime` kept track of the total time since the simulation start (100ms per step, unconnected to the real time). The `Substance.step` function takes this time and can use it to decide whether to keep the substance amount elevated or not.

It looks like this was partially-implemented before -- the `Substance.step` already took `milliseconds`, but this value was always 100, and it wasn't using the value. I wasn't sure if this was exactly how you were envisioning it.

This also adds pheomalenin.

https://www.pivotaltracker.com/story/show/155597017
https://www.pivotaltracker.com/story/show/155415643