### PR TITLE
Pausing model and all timers during assay or manipulations

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,17 +21,11 @@ class App extends React.Component<AppProps> {
     super(props);
     this.handleAssayToggle = this.handleAssayToggle.bind(this);
     this.handleAssayClear = this.handleAssayClear.bind(this);
-    this.simulationTick = this.simulationTick.bind(this);
     this.forceDropper = this.forceDropper.bind(this);
   }
 
   componentDidMount() {
-    this.simulationTick(0);
-  }
-
-  simulationTick(msPassed: number) {
-    rootStore.step(msPassed);
-    setTimeout(this.simulationTick.bind(this, STEP_MS), STEP_MS);
+    rootStore.startTimer(rootStore.step.bind(this, STEP_MS), STEP_MS, true);
   }
 
   handleViewChange(event: any) {

--- a/src/components/OrganelleWrapper.tsx
+++ b/src/components/OrganelleWrapper.tsx
@@ -198,11 +198,11 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
           const newCoords = this.state.dropperCoords.slice(0);
           newCoords.push({x: evt.e.layerX, y: evt.e.layerY});
           this.setState({dropperCoords: newCoords});
-          setTimeout(() => {
+          rootStore.startTimer(() => {
             const splicedCoords = this.state.dropperCoords.slice(0);
             splicedCoords.splice(0, 1);
             this.setState({dropperCoords: splicedCoords});
-          },         SUBSTANCE_ADDITION_MS);
+          },                   SUBSTANCE_ADDITION_MS);
         }
 
         // Handle the click in the Organelle model

--- a/src/utils.tsx
+++ b/src/utils.tsx
@@ -15,3 +15,49 @@ export function getUrlParamValue(key: string) {
   var params = JSON.parse(`{"${decodeURI(query).replace(/"/g, '\\"').replace(/&/g, '","').replace(/=/g, '":"')}"}`);
   return params[key];
 }
+
+/**
+ * A pausable timer class.
+ * 
+ * @param callback: the function to invoke after the specified time
+ * @param delay: the delay in milliseconds before the callback is invoked
+ * @param loop: if true, restarts the timer when it expires
+ */
+export class Timer {
+  callback: Function;
+  delay: number;
+  timerId: number;
+  start: number;
+  remaining: number;
+  loop: boolean;
+
+  constructor(callback: Function, delay: number, loop: boolean = false) {
+    this.callback = callback;
+    this.delay = delay;
+    this.remaining = delay;
+    this.loop = loop;
+
+    this.executeCallback = this.executeCallback.bind(this);
+
+    this.resume();
+  }
+
+  executeCallback() {
+    this.callback();
+    if (this.loop) {
+      this.remaining = this.delay;
+      this.resume();
+    }
+  }
+
+  pause() {
+    window.clearTimeout(this.timerId);
+    this.remaining -= Date.now() - this.start;
+  }
+
+  resume() {
+    this.start = Date.now();
+    window.clearTimeout(this.timerId);
+    this.timerId = window.setTimeout(this.executeCallback, this.remaining);
+  }
+}


### PR DESCRIPTION
Adds a new list of timers that can pause and loop to accomplish this.

Would be great if you could take a look at this, @sfentress. Pausing seems to work pretty well, except substance additions behave a little strangely - there is a gap in the creation of agents when the model is unpaused.

http://connected-bio.concord.org/branch/pause-model/

It doesn't seem like a big deal, but it does de-synchronize the agent addition with the dropper. Let me know if you think it's worth looking into. Alternatively, I could remove all `model.setTimeout` calls and manage everything with these pausable timers.