### PR TITLE
Add mystery labels for subs and locs on url param

### DIFF
--- a/src/components/Assay/AssayBarChart.tsx
+++ b/src/components/Assay/AssayBarChart.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { observer } from 'mobx-react';
 import { HorizontalBar } from 'react-chartjs-2';
-import { SubstanceType } from '../../models/Substance';
+import { SubstanceType, mysterySubstanceNames } from '../../models/Substance';
 import { IOrganelleRef } from '../../models/Organism';
 import { isEqual } from 'lodash';
 import { rootStore } from '../../stores/RootStore';
+import { appStore } from '../../stores/AppStore';
 import { assayStore } from '../../stores/AssayStore';
 import { stringToEnum } from '../../utils';
+import { mysteryOrganelleNames } from '../../models/Organelle';
 
 interface AssayBarProps {
   colors: object;
@@ -20,6 +22,10 @@ class AssayBarChart extends React.Component<AssayBarProps, AssayBarState> {
     let bars = [];
 
     let barColor =  this.props.colors[substanceType];
+
+    const label = appStore.mysteryLabels ?
+      mysterySubstanceNames[substanceType] : substanceType;
+
     bars.push({
       data: allAssays.map(function(assayInfo: IOrganelleRef) {
         let organism = rootStore.organisms.get(assayInfo.organism.id);
@@ -32,7 +38,7 @@ class AssayBarChart extends React.Component<AssayBarProps, AssayBarState> {
         }
         return substanceLevel;
       }),
-      label: substanceType,
+      label,
       backgroundColor: barColor,
       stack: 'Stack ' + barNum
     });
@@ -79,9 +85,12 @@ class AssayBarChart extends React.Component<AssayBarProps, AssayBarState> {
       allAssays.push(activeAssay);
     }
 
+    const organelleLabel = (type: string) =>
+      appStore.mysteryLabels ? mysteryOrganelleNames[type] : type;
+
     let data: Chart.ChartData = {
       datasets: [],
-      labels: allAssays.map(assay => [assay.organism.id, assay.organelleType.toLowerCase()]),
+      labels: allAssays.map(assay => [assay.organism.id, organelleLabel(assay.organelleType).toLowerCase()]),
     };
     activeSubstances.forEach((activeSubstance, i) => {
       data.datasets = data.datasets.concat(

--- a/src/components/Assay/AssayLineGraph.tsx
+++ b/src/components/Assay/AssayLineGraph.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
 import { clone } from 'mobx-state-tree';
 import { Scatter } from 'react-chartjs-2';
-import { SubstanceType } from '../../models/Substance';
+import { SubstanceType, mysterySubstanceNames } from '../../models/Substance';
 import { IOrganelleRef } from '../../models/Organism';
 import { rootStore } from '../../stores/RootStore';
+import { appStore } from '../../stores/AppStore';
 import { assayStore } from '../../stores/AssayStore';
 import { observer } from 'mobx-react';
 import { stringToEnum } from '../../utils';
+import { mysteryOrganelleNames } from '../../models/Organelle';
 
 interface AssayLineProps {
   colors: object;
@@ -56,10 +58,12 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
         y: val
       };
     });
-    let color =  this.props.colors[activeSubstance];
+    const label = appStore.mysteryLabels ?
+      mysterySubstanceNames[activeSubstance] : activeSubstance;
+    const color =  this.props.colors[activeSubstance];
     return {
       data,
-      label: activeSubstance,
+      label,
       borderWidth: 3,
       backgroundColor: color,
       borderColor: color,
@@ -139,6 +143,9 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
       const yAxisFontSize = lockedAssays.length < 3 ? 12 :
       lockedAssays.length < 4 ? 10 : 8;
 
+      const organelleLabel = appStore.mysteryLabels ?
+        mysteryOrganelleNames[lockedAssay.organelleType] : lockedAssay.organelleType;
+
       const options: any = Object.assign({}, defaultOptions, {
         title,
         legend,
@@ -152,7 +159,7 @@ class AssayLineGraph extends React.Component<AssayLineProps, AssayLineState> {
             scaleLabel: {
               display: true,
               fontSize: yAxisFontSize,
-              labelString: lockedAssays[i].organism.id + ' ' + lockedAssay.organelleType.toLowerCase()
+              labelString: lockedAssays[i].organism.id + ' ' + organelleLabel.toLowerCase()
             }
           }],
           xAxes: [{

--- a/src/components/OrganelleWrapper.tsx
+++ b/src/components/OrganelleWrapper.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { autorun, IReactionDisposer } from 'mobx';
 import { observer } from 'mobx-react';
 import { IOrganism, OrganelleRef } from '../models/Organism';
-import { OrganelleType } from '../models/Organelle';
+import { OrganelleType, mysteryOrganelleNames } from '../models/Organelle';
 import { View, appStore } from '../stores/AppStore';
 import { rootStore, Mode } from '../stores/RootStore';
 import { createModel } from 'organelle';
@@ -94,7 +94,7 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
       appStore.boxes.get(this.props.boxId).setModel(m);
       this.completeLoad();
     });
-    
+
     // Update model properties as they change
     this.disposers.push(autorun(() => {
       const newModelProperties = organism.modelProperties;
@@ -324,10 +324,12 @@ class OrganelleWrapper extends React.Component<OrganelleWrapperProps, OrganelleW
   }
 
   render() {
+    const hoverLabel = appStore.mysteryLabels ?
+      mysteryOrganelleNames[this.state.hoveredOrganelle] : this.state.hoveredOrganelle;
     const hoverDiv = this.state.hoveredOrganelle
       ? (
         <div className="hover-location">
-          {this.state.hoveredOrganelle}
+          {hoverLabel}
         </div>)
       : null;
 

--- a/src/components/SubstanceManipulator/SubstanceManipulator.tsx
+++ b/src/components/SubstanceManipulator/SubstanceManipulator.tsx
@@ -20,7 +20,7 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
   constructor(props: any) {
     super(props);
     this.state = {
-      selectedSubstance: SubstanceType.Hormone
+      selectedSubstance: SubstanceType[rootStore.activeSubstance]
     };
     this.updateSelection = this.updateSelection.bind(this);
     this.handleAddModeToggle = this.handleAddModeToggle.bind(this);
@@ -78,8 +78,8 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
-            value={SubstanceType.Hormone}
-            label={getSubstanceName(SubstanceType.Hormone)}
+            value={SubstanceType.Pheomelanin}
+            label={getSubstanceName(SubstanceType.Pheomelanin)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
           <RadioButton
@@ -99,8 +99,8 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
-            value={SubstanceType.Pheomelanin}
-            label={getSubstanceName(SubstanceType.Pheomelanin)}
+            value={SubstanceType.Hormone}
+            label={getSubstanceName(SubstanceType.Hormone)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
         </RadioButtonGroup>

--- a/src/components/SubstanceManipulator/SubstanceManipulator.tsx
+++ b/src/components/SubstanceManipulator/SubstanceManipulator.tsx
@@ -3,7 +3,8 @@ import { observer } from 'mobx-react';
 import './SubstanceManipulator.css';
 import { RaisedButton } from 'material-ui';
 import { RadioButton, RadioButtonGroup } from 'material-ui/RadioButton';
-import { SubstanceType } from '../../models/Substance';
+import { SubstanceType, mysterySubstanceNames } from '../../models/Substance';
+import { appStore } from '../../stores/AppStore';
 import { rootStore, Mode } from '../../stores/RootStore';
 
 interface SubstanceManipulatorProps {}
@@ -43,6 +44,10 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
 
   render() {
     let {mode} = rootStore;
+
+    const getSubstanceName = (name: string) =>
+      appStore.mysteryLabels ? mysterySubstanceNames[name] : name;
+
     return (
       <div className="substance-manipulator">
         <div className="substance-buttons">
@@ -74,28 +79,28 @@ class SubstanceManipulator extends React.Component<SubstanceManipulatorProps, Su
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.Hormone}
-            label="Hormone"
+            label={getSubstanceName(SubstanceType.Hormone)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.SignalProtein}
-            label="Activated Signal Protein"
+            label={getSubstanceName(SubstanceType.SignalProtein)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.Eumelanin}
-            label="Eumelanin"
+            label={getSubstanceName(SubstanceType.Eumelanin)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
           <RadioButton
             style={{width: '200px'}}
             labelStyle={{ fontSize: '12px'}}
             value={SubstanceType.Pheomelanin}
-            label="Pheomelanin"
+            label={getSubstanceName(SubstanceType.Pheomelanin)}
             disabled={!(mode === Mode.Normal || mode === Mode.Add || mode === Mode.Subtract)}
           />
         </RadioButtonGroup>

--- a/src/models/Organelle.tsx
+++ b/src/models/Organelle.tsx
@@ -13,6 +13,14 @@ export enum OrganelleType {
   NearbyCells = 'Nearby cells'
 }
 
+export const mysteryOrganelleNames: object = {
+  Melanosomes: 'Location 1',
+  Nucleus: 'Location 2',
+  Cytoplasm: 'Location 3',
+  Extracellular: 'Location 4',
+  'Nearby cells': 'Location 5'
+};
+
 export const Organelle: any = types
   .model('Organelle', {
     type: types.enumeration('OrganelleType', Object.keys(OrganelleType).map(key => OrganelleType[key])),

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -4,10 +4,10 @@ import { IOrganism } from './Organism';
 import { OrganelleType, IOrganelle } from './Organelle';
 
 export enum SubstanceType {
-  Hormone = 'Hormone',
+  Pheomelanin = 'Pheomelanin',
   SignalProtein = 'Activated Signal Protein',
   Eumelanin = 'Eumelanin',
-  Pheomelanin = 'Pheomelanin'
+  Hormone = 'Hormone'
 }
 
 export const mysterySubstanceNames: object = {

--- a/src/models/Substance.tsx
+++ b/src/models/Substance.tsx
@@ -10,6 +10,13 @@ export enum SubstanceType {
   Pheomelanin = 'Pheomelanin'
 }
 
+export const mysterySubstanceNames: object = {
+  Pheomelanin: 'Substance A',
+  'Activated Signal Protein': 'Substance B',
+  Eumelanin: 'Substance C',
+  Hormone: 'Substance D'
+};
+
 const substanceManipulationTime = 3500;
 
 export const Substance: any = types

--- a/src/stores/AppStore.tsx
+++ b/src/stores/AppStore.tsx
@@ -36,6 +36,10 @@ export const AppStore = types
     // whether we show graphs and add/remove buttons. In future we should explicitly say what views we want.
     // Default: true, set with `?showSubstances=false`
     showSubstances: types.boolean,
+    // whether the locations are substances are shown with true names (melanosome, pheomelanin) or
+    // "mystery" names (location 1, substance a)
+    // Default: false, set with `?mysteryLabels=true`
+    mysteryLabels: types.boolean,
     // which views we allow in the organism boxes
     // Default: ['None', 'Organism', 'Cell', 'Protein'], set with `?availableViews=Organism,Cell`
     _availableViews: types.array(types.string),
@@ -78,8 +82,8 @@ const showSubstances = getUrlParamValue('showSubstances') === 'false' ? false : 
 const availableViews = getUrlParamValue('availableViews') ?
   getUrlParamValue('availableViews').split(',') :
   [View.None, View.Organism, View.Cell, View.Protein];
-const availableOrgs = getUrlParamValue('availableOrgs') 
-  ? getUrlParamValue('availableOrgs').split(',').map((name: any) => name === 'BeachMouse' ? BeachMouse : FieldMouse) 
+const availableOrgs = getUrlParamValue('availableOrgs')
+  ? getUrlParamValue('availableOrgs').split(',').map((name: any) => name === 'BeachMouse' ? BeachMouse : FieldMouse)
   : [BeachMouse, FieldMouse];
 const initialViews = getUrlParamValue('initialViews') ?
   getUrlParamValue('initialViews').split(',').map((id: string) => stringToEnum(id, View)) :
@@ -87,12 +91,14 @@ const initialViews = getUrlParamValue('initialViews') ?
 
 let initialOrgs = [FieldMouse, FieldMouse];
 if (getUrlParamValue('initialOrgs')) {
-  initialOrgs = getUrlParamValue('initialOrgs').split(',').map((name: any) => 
+  initialOrgs = getUrlParamValue('initialOrgs').split(',').map((name: any) =>
     name === 'BeachMouse' ? BeachMouse : FieldMouse);
 } else if (getUrlParamValue('initialOrg')) {
   const org = (getUrlParamValue('initialOrg') === 'BeachMouse' ? BeachMouse : FieldMouse);
   initialOrgs = [org, org];
 }
+
+const mysteryLabels = getUrlParamValue('mysteryLabels') === 'true' ? true : false;
 
 export const appStore = AppStore.create({
   boxes: {
@@ -108,6 +114,7 @@ export const appStore = AppStore.create({
     }
   },
   showSubstances: showSubstances,
+  mysteryLabels: mysteryLabels,
   _availableViews: availableViews,
   _availableOrgs: availableOrgs
 });

--- a/src/stores/AssayStore.tsx
+++ b/src/stores/AssayStore.tsx
@@ -34,10 +34,10 @@ const showLineGraphs = getUrlParamValue('showLineGraphs') === 'true' ? true : fa
 
 export const assayStore = AssayStore.create({
   visibleSubstances: {
-    [SubstanceType.Hormone]: true,
+    [SubstanceType.Pheomelanin]: true,
     [SubstanceType.SignalProtein]: true,
     [SubstanceType.Eumelanin]: true,
-    [SubstanceType.Pheomelanin]: true
+    [SubstanceType.Hormone]: true
   },
   graph: GraphType.Bar,
   showLineGraphs: showLineGraphs

--- a/src/stores/RootStore.tsx
+++ b/src/stores/RootStore.tsx
@@ -67,7 +67,7 @@ const RootStore = types
             delete timers[timerKey];
           }
         },
-        delay, 
+        delay,
         loop);
     },
 
@@ -76,7 +76,7 @@ const RootStore = types
       if (organismsHistory.length > 20) {
         organismsHistory.splice(0, 1);
       }
-      
+
       self.organisms.keys().forEach(orgKey => {
         self.organisms.get(orgKey).step(self.time, organismsHistory);
       });
@@ -116,9 +116,9 @@ const RootStore = types
 
     changeSubstanceLevel(organelleRef: IOrganelleRef) {
       self.organisms.get(organelleRef.organism.id).incrementOrganelleSubstance(
-        organelleRef.organelleType, 
-        stringToEnum(self.activeSubstance, SubstanceType), 
-        self.activeSubstanceAmount, 
+        organelleRef.organelleType,
+        stringToEnum(self.activeSubstance, SubstanceType),
+        self.activeSubstanceAmount,
         self.time);
       self.setMode(Mode.Normal);
     },
@@ -143,7 +143,7 @@ export const rootStore = RootStore.create({
     'Beach Mouse': BeachMouse,
     'Field Mouse': FieldMouse
   },
-  activeSubstance: SubstanceType.Hormone,
+  activeSubstance: SubstanceType.Pheomelanin,
   appStore,
   assayStore
 });


### PR DESCRIPTION
With the url parameter `?mysteryLabels=true` we will replace the real
names of substances and cell locations with mystery names.

https://www.pivotaltracker.com/story/show/159177086
https://www.pivotaltracker.com/story/show/159158854
https://www.pivotaltracker.com/story/show/159158836